### PR TITLE
Free static LinkedRoot when no subscribers

### DIFF
--- a/src/c/app-focus.c
+++ b/src/c/app-focus.c
@@ -107,6 +107,8 @@ void events_app_focus_service_unsubscribe(EventHandle handle) {
   linked_list_remove(s_handler_list, index);
   if (linked_list_count(s_handler_list) == 0) {
     app_focus_service_unsubscribe();
+    free(s_handler_list);
+    s_handler_list = NULL;
   }
 }
 

--- a/src/c/appmessage.c
+++ b/src/c/appmessage.c
@@ -131,6 +131,8 @@ void events_app_message_unsubscribe(EventHandle handle) {
   linked_list_remove(s_handler_list, index);
   if (linked_list_count(s_handler_list) == 0) {
     app_message_deregister_callbacks();
+    free(s_handler_list);
+    s_handler_list = NULL;
   }
 }
 

--- a/src/c/battery-state.c
+++ b/src/c/battery-state.c
@@ -69,6 +69,8 @@ void events_battery_state_service_unsubscribe(EventHandle handle) {
   linked_list_remove(s_handler_list, index);
   if (linked_list_count(s_handler_list) == 0) {
     battery_state_service_unsubscribe();
+    free(s_handler_list);
+    s_handler_list = NULL;
   }
 }
 

--- a/src/c/connection.c
+++ b/src/c/connection.c
@@ -95,6 +95,8 @@ void events_connection_service_unsubscribe(EventHandle handle) {
   linked_list_remove(s_handler_list, index);
   if (linked_list_count(s_handler_list) == 0) {
     connection_service_unsubscribe();
+    free(s_handler_list);
+    s_handler_list = NULL;
   }
 }
 

--- a/src/c/health.c
+++ b/src/c/health.c
@@ -51,6 +51,8 @@ bool events_health_service_events_unsubscribe(EventHandle handle) {
   free(linked_list_get(s_handler_list, index));
   linked_list_remove(s_handler_list, index);
   if (linked_list_count(s_handler_list) == 0) {
+    free(s_handler_list);
+    s_handler_list = NULL;
     return health_service_events_unsubscribe();
   }
   return true;

--- a/src/c/tick-timer.c
+++ b/src/c/tick-timer.c
@@ -99,6 +99,8 @@ void events_tick_timer_service_unsubscribe(EventHandle handle) {
   s_current_subscription = 0;
   if (linked_list_count(s_handler_list) == 0) {
     tick_timer_service_unsubscribe();
+    free(s_handler_list);
+    s_handler_list = NULL;
   } else {
     linked_list_foreach(s_handler_list, prv_add_to_subscription, NULL);
     tick_timer_service_subscribe(s_current_subscription, prv_tick);


### PR DESCRIPTION
When the last subscriber unsubscribes from a service, free the static
LinkedRoot pointer and set it to NULL. This ensures we don't leak memory
if a service never gets another subscriber. It also doesn't hide true
memory leaks when the app quits; currently each service "leaks" around 8
bytes when the app closes.
