### PR TITLE
Free empty list

### DIFF
--- a/src/c/appmessage.c
+++ b/src/c/appmessage.c
@@ -130,6 +130,8 @@ void events_app_message_unsubscribe(EventHandle handle) {
   free(linked_list_get(s_handler_list, index));
   linked_list_remove(s_handler_list, index);
   if (linked_list_count(s_handler_list) == 0) {
+    free(s_handler_list);
+    s_handler_list = NULL;
     app_message_deregister_callbacks();
   }
 }


### PR DESCRIPTION
or 8 bytes are not correctly deallocated at the end :
`[22:40:49] ocess_manager.c:421> Heap Usage for App <demo-ename: Total Size <61740B> Used <644B> Still allocated <8B>`
