### PR TITLE
Add support for emery and flint

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "A library to fix the Pebble SDK's event services.",
   "repository": "Katharine/pebble-events",
   "dependencies": {
-    "@smallstoneapps/linked-list": "^1.2.1"
+    "@rebble/linked-list": "^1.5.0"
   },
   "pebble": {
     "projectType": "package",
@@ -17,7 +17,9 @@
       "aplite",
       "basalt",
       "chalk",
-      "diorite"
+      "diorite",
+      "emery",
+      "flint"
     ],
     "resources": {
       "media": []


### PR DESCRIPTION
Requires a `linked-list` from the rebble repo since it has both emery and flint support already